### PR TITLE
Migrate from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,59 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Cache Node.js modules
+      uses: actions/cache@v2
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.OS }}-node-
+          ${{ runner.OS }}-
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,13 +5,12 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ develop ]
+    branches: [develop]
   pull_request:
-    branches: [ develop ]
+    branches: [develop]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     services:
@@ -40,20 +39,29 @@ jobs:
         node-version: [10.x, 12.x, 14.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Cache Node.js modules
-      uses: actions/cache@v2
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.OS }}-node-
-          ${{ runner.OS }}-
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm test
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      - run: npm ci
+      - run: npm install
+      - run: npm run build --if-present
+      - name: Tests and Coverage
+        run: npm run coverage
+        env:
+          CI: true
+          TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+          EMAIL: ${{ secrets.EMAIL }}
+          PASS: ${{ secrets.PASS }}
+          JWT_KEY: ${{ secrets.JWT_KEY }}
+          PORT: ${{ secrets.PORT }}

--- a/package.json
+++ b/package.json
@@ -62,8 +62,9 @@
     "build": "babel ./src --out-dir build",
     "start": "npm run seed && npm run build && node build",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
-    "createdb": "NODE_ENV=test npx sequelize-cli db:create",
-    "test": "npm run createdb && npm run seed:test && NODE_ENV=test mocha --timeout 20000 ./src/test/**.js --require @babel/register --exit",
+    "create:db": "cross-env NODE_ENV=test sequelize db:create",
+    "drop:db": "cross-env NODE_ENV=test sequelize db:drop",
+    "test": "npm run drop:db && npm run create:db && npm run seed:test && NODE_ENV=test mocha --timeout 40000 ./src/test/**.js --require @babel/register --exit",
     "coverage": "nyc npm run test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "build": "babel ./src --out-dir build",
     "start": "npm run seed && npm run build && node build",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
-    "test": "npm run seed:test && cross-env NODE_ENV=test mocha --timeout 40000 ./src/test/**.js --require @babel/register --exit",
+    "createdb": "NODE_ENV=test npx sequelize-cli db:create",
+    "test": "npm run createdb && npm run seed:test && NODE_ENV=test mocha --timeout 20000 ./src/test/**.js --require @babel/register --exit",
     "coverage": "nyc npm run test"
   },
   "repository": {

--- a/src/database/config/config.js
+++ b/src/database/config/config.js
@@ -1,19 +1,18 @@
 require('dotenv').config();
 
+const { DEV_DATABASE_URL, DATABASE_URL, TEST_DATABASE_URL } = process.env;
+
 module.exports = {
   development: {
-    url: process.env.DEV_DATABASE_URL,
+    url: DEV_DATABASE_URL,
     dialect: 'postgres',
   },
   test: {
-    url: process.env.TEST_DATABASE_URL,
+    url: TEST_DATABASE_URL,
     dialect: 'postgres',
-    database: 'phantom_test',
-    username: 'postgres',
-    password: 'postgres'
   },
   production: {
-    url: process.env.DATABASE_URL,
+    url: DATABASE_URL,
     dialect: 'postgres',
     use_env_variable: 'DATABASE_URL',
   },

--- a/src/database/config/config.js
+++ b/src/database/config/config.js
@@ -8,6 +8,9 @@ module.exports = {
   test: {
     url: process.env.TEST_DATABASE_URL,
     dialect: 'postgres',
+    database: 'phantom_test',
+    username: 'postgres',
+    password: 'postgres'
   },
   production: {
     url: process.env.DATABASE_URL,

--- a/src/helpers/signToken.js
+++ b/src/helpers/signToken.js
@@ -4,6 +4,6 @@ import { config } from 'dotenv';
 config();
 
 export default (data) => {
-  const token = jwt.sign(data, process.env.JWT_KEY);
+  const token = jwt.sign(data, process.env.JWT_KEY || 'thisShouldWork');
   return token;
 };

--- a/src/helpers/signToken.js
+++ b/src/helpers/signToken.js
@@ -4,6 +4,6 @@ import { config } from 'dotenv';
 config();
 
 export default (data) => {
-  const token = jwt.sign(data, process.env.JWT_KEY || 'thisShouldWork');
+  const token = jwt.sign(data, process.env.JWT_KEY);
   return token;
 };


### PR DESCRIPTION
## Description
This will setup GitHub Actions for the repo.

### Changes introduced:

* `npm run test` will first create a database using `npx` before running tests
* A default secret key was added for signing token without `.env`
* `.env` was completely removed. Whoever added it to `.gitignore` forgot to `git rm --cached` that's why it was still there.

### How to test

* Examine the latest job build history


### To do

* Remove Travis build. This will be after we've become comfortable with Actions
### Relevant info

* Issue #44 